### PR TITLE
Fix label for memorized words toggle

### DIFF
--- a/Screens/Flashcards/CategoriesScreen/FlashcardList/VocabExercises/VocabularyExercisesScreen/VocabularyExercisesScreen.jsx
+++ b/Screens/Flashcards/CategoriesScreen/FlashcardList/VocabExercises/VocabularyExercisesScreen/VocabularyExercisesScreen.jsx
@@ -275,7 +275,7 @@ const VocabularyExercisesScreen = ({ route, navigation }) => {
             >
             {darkModeEnabled && <View style={dynamicStyles.darkModeOverlayCircle} />}
 
-                <Text style={dynamicStyles.floatingButtonText}>{showMemorizedWords ? 'Ocultar' : '  ?  '}</Text>
+                <Text style={dynamicStyles.floatingButtonText}>{showMemorizedWords ? 'Ocultar' : 'Mostrar'}</Text>
             </TouchableOpacity>
         </View>
     );


### PR DESCRIPTION
## Summary
- correct the floating button text on the vocabulary exercises screen

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68406e6ef2e4832eba9d1be34c26fd9b